### PR TITLE
Detect pace device when using hybrid rom

### DIFF
--- a/service/src/main/java/com/amazmod/service/util/SystemProperties.java
+++ b/service/src/main/java/com/amazmod/service/util/SystemProperties.java
@@ -29,6 +29,7 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -232,7 +233,7 @@ public class SystemProperties {
     }
 
     public static boolean isPace(){
-        return checkIfModel(Constants.BUILD_PACE_MODELS, "Pace");
+        return checkIfModel(Constants.BUILD_PACE_MODELS, "Pace") || new File("/system/.pace_hybrid").exists();
     }
 
     public static boolean isStratos(){


### PR DESCRIPTION
Without this it would check just if props have A1602 or A1612 but in hybrid rom that prop is A1609 always, so we have to check if /system/.pace_hybrid file exists