### PR TITLE
Avoid isStratos() returning true when it's pace running hybrid rom

### DIFF
--- a/service/src/main/java/com/amazmod/service/util/SystemProperties.java
+++ b/service/src/main/java/com/amazmod/service/util/SystemProperties.java
@@ -237,7 +237,7 @@ public class SystemProperties {
     }
 
     public static boolean isStratos(){
-        return checkIfModel(Constants.BUILD_STRATOS_MODELS, "Stratos");
+        return checkIfModel(Constants.BUILD_STRATOS_MODELS, "Stratos") && !isPace();
     }
 
     public static boolean isVerge(){


### PR DESCRIPTION
Without this both isPace() and isStratos() will return true in hybrid rom
I forgot adding this in https://github.com/AmazMod/AmazMod/commit/6e6a6535cb5d3bd9025df8f322dc6b19af3d1cf1